### PR TITLE
allow to pass extra HTTPRequest kwargs (e.g. request_timeout).

### DIFF
--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -17,6 +17,8 @@ class ESConnection(object):
         self.url = "http://%(host)s:%(port)s" % {"host": host, "port": port}
         self.bulk = BulkList()
         self.client = AsyncHTTPClient(self.io_loop)
+        self.httprequest_kwargs = {}     #extra kwargs passed to tornado's HTTPRequest class
+                                         #e.g. request_timeout
 
     def create_path(self, method, **kwargs):
         index = kwargs.get('index', '_all')
@@ -59,13 +61,13 @@ class ESConnection(object):
 
     def post_by_path(self, path, callback, source):
         url = '%(url)s%(path)s' % {"url": self.url, "path": path}
-        request_http = HTTPRequest(url, method="POST", body=source)
+        request_http = HTTPRequest(url, method="POST", body=source, **self.httprequest_kwargs)
         self.client.fetch(request=request_http, callback=callback)
 
     @return_future
     def get_by_path(self, path, callback):
         url = '%(url)s%(path)s' % {"url": self.url, "path": path}
-        self.client.fetch(url, callback)
+        self.client.fetch(url, callback, **self.httprequest_kwargs)
 
     @return_future
     def get(self, index, type, uid, callback):
@@ -108,7 +110,8 @@ class ESConnection(object):
             "path": path,
             "querystring": urlencode(parameters or {})
         }
-        request_arguments = dict(method=method)
+        request_arguments = dict(self.httprequest_kwargs)
+        request_arguments['method'] = method
 
         if body is not None:
             request_arguments['body'] = body


### PR DESCRIPTION
tornado.httpclient.HTTPRequest class has default 20s for request_timeout. It's too short sometimes for my use case. I added an attribute "httprequest_kwargs" to ESConnection class, it will be passed to HTTPRequest class when making actual requests. That way, users can fine-tune some parameters for making HTTP requests if they want.

Cheers,

Chunlei
