### PR TITLE
Allow specifying the protocol to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = '2.0.1'
+VERSION = '2.1.0'
 
 setup(
     name='tornadoes',
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'tornado>=3.0.0,<=3.2.1',
+        'tornado>=3.0.0,<3.3.0',
     ],
     tests_require=[
         'unittest2',

--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -12,9 +12,9 @@ from tornado.concurrent import return_future
 
 class ESConnection(object):
 
-    def __init__(self, host='localhost', port='9200', io_loop=None):
+    def __init__(self, host='localhost', port='9200', io_loop=None, protocol='http'):
         self.io_loop = io_loop or IOLoop.instance()
-        self.url = "http://%(host)s:%(port)s" % {"host": host, "port": port}
+        self.url = "%(protocol)s://%(host)s:%(port)s" % {"protocol": protocol, "host": host, "port": port}
         self.bulk = BulkList()
         self.client = AsyncHTTPClient(self.io_loop)
         self.httprequest_kwargs = {}     #extra kwargs passed to tornado's HTTPRequest class


### PR DESCRIPTION
Most often one will use HTTP, on any port. Yet, it may be necessary
to use HTTPS, such as in authenticated/authorized accesses.

Both positioning the new `protocol` argument in the end and using
`'http'` as it's default value guarantee backward compatibility.

Also, support all upcoming releases of tornado 3.2.\* branch.
