### PR TITLE
Add "parameters" argument to ESConnection.get

### DIFF
--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -71,11 +71,11 @@ class ESConnection(object):
         self.client.fetch(url, callback, **self.httprequest_kwargs)
 
     @return_future
-    def get(self, index, type, uid, callback):
+    def get(self, index, type, uid, callback, parameters=None):
         def to_dict_callback(response):
             source = json_decode(response.body).get('_source', {})
             callback(source)
-        self.request_document(index, type, uid, callback=to_dict_callback)
+        self.request_document(index, type, uid, callback=to_dict_callback, parameters=parameters)
 
     @return_future
     def put(self, index, type, uid, contents, parameters=None, callback=None):


### PR DESCRIPTION
It can be used e.g. for routing and to include/exclude _source fields.

In many other methods callback is the last argument, but it is not optional for `.get`, and `parameters` is optional, so we can't maintain that order.
