### PR TITLE
Don't pin dependency on specific version of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     zip_safe=True,
     install_requires=[
         'tornado>=3.0.0,<4.1.0',
-        'six==1.7.3',
+        'six>=1.7.3',
     ],
     tests_require=[
         'unittest2',


### PR DESCRIPTION
Currently the package is pinned to `six==1.7.3` which causes some problems... This change allows tornado-es work with newer versions of six.