### PR TITLE
Add 'search_type' to list of parameters

### DIFF
--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -23,7 +23,7 @@ class ESConnection(object):
         index = kwargs.get('index', '_all')
         type_ = '/' + kwargs.get('type') if 'type' in kwargs else ''
         parameters = {}
-        for param in ['size', 'from', 'routing']:
+        for param in ['size', 'from', 'routing', 'search_type']:
             value = kwargs.get(param, None)
             if value:
                 parameters[param] = value


### PR DESCRIPTION
allow the `search_type` to be specified as a request parameter

http://www.elastic.co/guide/en/elasticsearch/reference/1.x/search-request-search-type.html