### PR TITLE
Add compatibility with Tornado 4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'tornado>=3.0.0,<4.3.0',
+        'tornado>=3.0.0,<4.4.0',
         'six>=1.7.3',
     ],
     tests_require=[


### PR DESCRIPTION
4.3 was released in November, no reason not to use it if it's compatible :)

@luizgpsantos 

```
(env)blampe@b:~/src/tornado-es (tornado)  08:52:12
$ pip freeze | grep tornado
tornado==4.3
(env)blampe@b:~/src/tornado-es (tornado)  08:52:17
$ make test
...
Ran 28 tests in 0.611s

OK
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
tornadoes/__init__.py      75      1     14      1    98%   56, 55->56
tornadoes/models.py        17      0      0      0   100%
-------------------------------------------------------------------
TOTAL                      92      1     14      1    98%
```