### PR TITLE
added type mapping to multi_search

### DIFF
--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -46,8 +46,8 @@ class ESConnection(object):
         }))
         self.post_by_path(path, callback, source)
 
-    def multi_search(self, index, source):
-        self.bulk.add(index, source)
+    def multi_search(self, index, source, type=None):
+        self.bulk.add(index, source, type)
 
     @return_future
     def apply_search(self, callback, params={}):

--- a/tornadoes/models.py
+++ b/tornadoes/models.py
@@ -12,9 +12,11 @@ class BulkList(object):
         with self.lock:
             self.bulk_list = []
 
-    def add(self, index, source):
+    def add(self, index, source, stype):
         with self.lock:
             command = {"index": index} if index else {}
+            if stype:
+                command['type'] = stype
             source = "%s\n%s" % (json_encode(command), json_encode(source))
             self.bulk_list.append(source)
 


### PR DESCRIPTION
I've added the type mapping to multi_search, so now it's possible to make multi searches by index, type mapping, and both.

Quick usage:

`self.es.multi_search(index="my_index", source={"query": {"term": {"doc": "freetext"}}}, type="my_type")`

`result = yield self.es.apply_search()`

hope it helps