### PR TITLE
Feature: custom client and partial document

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ coverage
 nose
 tox
 yanc
+mock

--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -81,6 +81,18 @@ class ESConnection(object):
             parameters=parameters, callback=callback)
 
     @return_future
+    def update(self, index, type, uid, contents, callback=None):
+        path = "/%(index)s/%(type)s/%(uid)s/_update" % {
+            "index": index,
+            "type": type,
+            "uid": uid
+        }
+
+        partial = { "doc": contents }
+
+        self.post_by_path(path, callback, source=json_encode(partial))
+
+    @return_future
     def delete(self, index, type, uid, parameters=None, callback=None):
         self.request_document(index, type, uid, "DELETE", parameters=parameters, callback=callback)
 

--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -11,11 +11,11 @@ from tornado.concurrent import return_future
 
 class ESConnection(object):
 
-    def __init__(self, host='localhost', port='9200', io_loop=None, protocol='http'):
+    def __init__(self, host='localhost', port='9200', io_loop=None, protocol='http', custom_client=None):
         self.io_loop = io_loop or IOLoop.instance()
         self.url = "%(protocol)s://%(host)s:%(port)s" % {"protocol": protocol, "host": host, "port": port}
         self.bulk = BulkList()
-        self.client = AsyncHTTPClient(self.io_loop)
+        self.client = custom_client or AsyncHTTPClient(self.io_loop)
         self.httprequest_kwargs = {}     # extra kwargs passed to tornado's HTTPRequest class e.g. request_timeout
 
     def create_path(self, method, **kwargs):

--- a/tornadoes/tests/unit/test_tornadoes.py
+++ b/tornadoes/tests/unit/test_tornadoes.py
@@ -140,6 +140,19 @@ class TestESConnection(ESConnectionTestBase):
             self.assertEqual(response['_type'], 'document')
             self.assertEqual(response['_id'], doc_id)
 
+    def test_update_partial_document(self):
+        uid = escape.url_escape("http://localhost/noticia/5/fast")
+        self.es_connection.update(index='teste',
+                                  type='materia',
+                                  uid=uid,
+                                  contents={"Tags": "nova"},
+                                  callback=self.stop)
+
+        response = self._verify_status_code_and_return_response()
+
+        self.assertEqual(response["_index"], 'teste')
+        self.assertEqual(response["_version"], 2)
+
     def test_count_specific_index(self):
         self.es_connection.count(callback=self.stop, index="outroteste")
         response = self._verify_status_code_and_return_response()


### PR DESCRIPTION
Hello guys.

I've been using the tornadoes for some of our projects and we came up with two features:

 - **Use custom HTTP client:** we use https://github.com/globocom/tornado-alf for authenticated requests

 - **Updating Partial**: There is an option in ElasticSearch that is partial update. It does not override the whole doc as `put` option does.

I implemented both in this PR. Feel free to review