### PR TITLE
Elasticsearch 5 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,101 @@
+.idea/
+*.iml
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
 build/
+develop-eggs/
 dist/
-tornadoes.egg-info/
-*.pyc
-.pydevproject
-.project
-.settings/
-.coverage
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
 .tox/
+test-results
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ script:
 
     # ES 5.0 branch
     - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.deb
+    - sudo apt-get install oracle-java8-set-default
     - sudo apt-get purge elasticsearch -fy
     - sudo dpkg -i --force-confnew elasticsearch-5.0.0.deb
     - sudo service elasticsearch start
@@ -131,6 +132,7 @@ script:
 
     # ES 5.5.1 branch
     - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.deb
+    - sudo apt-get install oracle-java8-set-default
     - sudo apt-get purge elasticsearch -fy
     - sudo dpkg -i --force-confnew elasticsearch-5.5.1.deb
     - sudo service elasticsearch start

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,3 +118,23 @@ script:
     - curl http://localhost:9200/
     - make test
     - sudo service elasticsearch stop
+
+    # ES 5.0 branch
+    - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.deb
+    - sudo apt-get purge elasticsearch -fy
+    - sudo dpkg -i --force-confnew elasticsearch-5.0.0.deb
+    - sudo service elasticsearch start
+    - sleep 10
+    - curl http://localhost:9200/
+    - make test
+    - sudo service elasticsearch stop
+
+    # ES 5.5.1 branch
+    - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.deb
+    - sudo apt-get purge elasticsearch -fy
+    - sudo dpkg -i --force-confnew elasticsearch-5.5.1.deb
+    - sudo service elasticsearch start
+    - sleep 10
+    - curl http://localhost:9200/
+    - make test
+    - sudo service elasticsearch stop

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'tornado>=3.0.0,<4.4.0',
+        'tornado>=3.0.0',
         'six>=1.7.3',
     ],
     tests_require=[

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 -e .
-coverage
+coverage==4.2
 nose
 tox
 yanc

--- a/tornadoes/__init__.py
+++ b/tornadoes/__init__.py
@@ -10,62 +10,65 @@ from tornado.concurrent import return_future
 
 
 class ESConnection(object):
+    _MATCH_ALL_QUERY = {"query": {"match_all": {}}}
 
-    def __init__(self, host='localhost', port='9200', io_loop=None, protocol='http', custom_client=None):
+    def __init__(self, host='localhost', port='9200', io_loop=None, protocol='http', custom_client=None,
+                 http_request_kwargs=None):
         self.io_loop = io_loop or IOLoop.instance()
         self.url = "%(protocol)s://%(host)s:%(port)s" % {"protocol": protocol, "host": host, "port": port}
         self.bulk = BulkList()
         self.client = custom_client or AsyncHTTPClient(self.io_loop)
-        self.httprequest_kwargs = {}     # extra kwargs passed to tornado's HTTPRequest class e.g. request_timeout
+
+        # extra kwargs passed to tornado's HTTPRequest class e.g. request_timeout
+        self.http_request_kwargs = http_request_kwargs or {}
 
     @staticmethod
-    def from_uri(uri, io_loop=None, custom_client=None):
+    def _create_query_string(params):
+        """
+        Support Elasticsearch 5.X
+        """
+        parameters = params or {}
+
+        for param, value in parameters.items():
+            param_value = str(value).lower() if isinstance(value, bool) else value
+            parameters[param] = param_value
+
+        return urlencode(parameters)
+
+    @classmethod
+    def from_uri(cls, uri, io_loop=None, custom_client=None, http_request_kwargs=None):
         parsed = urlparse(uri)
 
         if not parsed.hostname or not parsed.scheme:
             raise ValueError('Invalid URI')
 
-        return ESConnection(**{
-            'host': parsed.hostname,
-            'protocol': parsed.scheme,
-            'port': parsed.port,
-            'io_loop': io_loop,
-            'custom_client': custom_client
-        })
+        return cls(host=parsed.hostname, protocol=parsed.scheme, port=parsed.port, io_loop=io_loop,
+                   custom_client=custom_client, http_request_kwargs=http_request_kwargs)
 
-    def create_path(self, method, **kwargs):
-        index = kwargs.pop('index', '_all')
-        doc_type = '/%s' % kwargs.pop('type', '')
+    @staticmethod
+    def create_path(method, index='_all', type='', **kwargs):
+        query_string = ESConnection._create_query_string(kwargs)
 
-        parameters = {}
-        for param, value in kwargs.items():
-            parameters[param] = value
+        path = "/%(index)s/%(type)s/_%(method)s" % {"method": method, "index": index, "type": type}
 
-        path = "/%(index)s%(type)s/_%(method)s" % {
-            "method": method,
-            "index": index,
-            "type": doc_type
-        }
-        if parameters:
-            path += '?' + urlencode(parameters)
+        if query_string:
+            path += '?' + query_string
 
         return path
 
     @return_future
-    def search(self, callback, **kwargs):
-        path = self.create_path("search", **kwargs)
-        source = json_encode(kwargs.get('source', {
-            "query": {
-                "match_all": {}
-            }
-        }))
+    def search(self, callback, index='_all', type='', source=None, **kwargs):
+        source = json_encode(source or self._MATCH_ALL_QUERY)
+        path = self.create_path("search", index=index, type=type, **kwargs)
+
         self.post_by_path(path, callback, source)
 
     def multi_search(self, index, source):
         self.bulk.add(index, source)
 
     @return_future
-    def apply_search(self, callback, params={}):
+    def apply_search(self, callback, params=None):
+        params = params or {}
         path = "/_msearch"
         if params:
             path = "%s?%s" % (path, urlencode(params))
@@ -74,13 +77,13 @@ class ESConnection(object):
 
     def post_by_path(self, path, callback, source):
         url = '%(url)s%(path)s' % {"url": self.url, "path": path}
-        request_http = HTTPRequest(url, method="POST", body=source, **self.httprequest_kwargs)
+        request_http = HTTPRequest(url, method="POST", body=source, **self.http_request_kwargs)
         self.client.fetch(request=request_http, callback=callback)
 
     @return_future
     def get_by_path(self, path, callback):
         url = '%(url)s%(path)s' % {"url": self.url, "path": path}
-        self.client.fetch(url, callback, **self.httprequest_kwargs)
+        self.client.fetch(url, callback, **self.http_request_kwargs)
 
     @return_future
     def get(self, index, type, uid, callback, parameters=None):
@@ -112,16 +115,15 @@ class ESConnection(object):
         self.request_document(index, type, uid, "DELETE", parameters=parameters, callback=callback)
 
     @return_future
-    def count(self, index="_all", type=None, source='', parameters=None, callback=None):
-        path = '/{}'.format(index)
+    def count(self, index="_all", type='', source='', parameters=None, callback=None):
+        """
+        The query can either be provided using a simple query string as a parameter 'q',
+        or using the Query DSL defined within the request body (source).
+        Notice there are additional query string parameters that could be added only with the first option.
+        """
+        parameters = parameters or {}
 
-        if type:
-            path += '/{}'.format(type)
-
-        path += '/_count'
-
-        if parameters:
-            path += '?{}'.format(urlencode(parameters or {}))
+        path = self.create_path('count', index=index, type=type, **parameters)
 
         if source:
             source = json_encode(source)
@@ -129,13 +131,15 @@ class ESConnection(object):
         self.post_by_path(path=path, callback=callback, source=source)
 
     def request_document(self, index, type, uid, method="GET", body=None, parameters=None, callback=None):
+        query_string = ESConnection._create_query_string(parameters)
+
         path = '/{index}/{type}/{uid}'.format(**locals())
         url = '%(url)s%(path)s?%(querystring)s' % {
             "url": self.url,
             "path": path,
-            "querystring": urlencode(parameters or {})
+            "querystring": query_string
         }
-        request_arguments = dict(self.httprequest_kwargs)
+        request_arguments = dict(self.http_request_kwargs)
         request_arguments['method'] = method
 
         if body is not None:

--- a/tornadoes/tests/unit/test_tornadoes.py
+++ b/tornadoes/tests/unit/test_tornadoes.py
@@ -8,6 +8,8 @@ from tornado.testing import AsyncTestCase, gen_test
 from tornado.ioloop import IOLoop
 from mock import Mock
 
+from six.moves.urllib.parse import urlencode
+
 
 class ESConnectionTestBase(AsyncTestCase):
 
@@ -129,7 +131,7 @@ class TestESConnection(ESConnectionTestBase):
             self.assertEqual(response_dict['_index'], 'test')
             self.assertEqual(response_dict['_type'], 'document')
             self.assertEqual(response_dict['_id'], doc_id)
-            self.assertIn('refresh=True', response.request.url)
+            self.assertIn('refresh=true', response.request.url)
         finally:
             self.es_connection.delete("test", "document", doc_id,
                                       parameters={'refresh': True}, callback=self.stop)
@@ -170,26 +172,24 @@ class TestESConnection(ESConnectionTestBase):
         response = self._verify_status_code_and_return_response()
         self.assertEqual(response["count"], 1)
 
-    def test_count_specific_query_with_parameters(self):
+    def test_count_specific_query_with_illegal_parameters(self):
         source = {"query": {"term": {"_id": "171171"}}}
         source = self._set_count_query(source)
         parameters = {'refresh': True}
         self.es_connection.count(callback=self.stop, source=source, parameters=parameters)
         response = self.wait()
-        response_dict = self._verify_response_and_returns_dict(response)
-        self.assertEqual(response_dict["count"], 1)
-        self.assertTrue(response.request.url.endswith('_count?refresh=True'))
+        if self.version < 5:
+            self.assertTrue(response.code in [200, 201], "Wrong response code: %d." % response.code)
+        else:
+            self.assertEqual(response.code, 400)
 
     def test_count_specific_query_with_many_parameters(self):
-        source = {"query": {"term": {"_id": "171171"}}}
-        source = self._set_count_query(source)
-        parameters = {'df': '_id', 'test': True}
-        self.es_connection.count(callback=self.stop, source=source, parameters=parameters)
+        parameters = {'df': '_id', 'q': '_id:171171'}
+        self.es_connection.count(callback=self.stop, parameters=parameters)
         response = self.wait()
         response_dict = self._verify_response_and_returns_dict(response)
         self.assertEqual(response_dict["count"], 1)
         self.assertTrue('df=_id' in response.request.url)
-        self.assertTrue('test=True' in response.request.url)
 
 
 class TestESConnectionWithTornadoGen(ESConnectionTestBase):
@@ -264,7 +264,7 @@ class TestESConnectionWithTornadoGen(ESConnectionTestBase):
             self.assertEqual(response_dict['_index'], 'test')
             self.assertEqual(response_dict['_type'], 'document')
             self.assertEqual(response_dict['_id'], doc_id)
-            self.assertIn('refresh=True', response.request.url)
+            self.assertIn('refresh=true', response.request.url)
         finally:
             response = yield self.es_connection.delete("test", "document", doc_id,
                                                        parameters={'refresh': True})
@@ -293,13 +293,19 @@ class TestESConnectionWithTornadoGen(ESConnectionTestBase):
         self.assertCount(response, 1)
 
     @gen_test
+    def test_count_specific_query_as_parameter_with_additional_parameters(self):
+        parameters = {'q': '_id:171171', 'df': '_id'}
+        response = yield self.es_connection.count(callback=self.stop, parameters=parameters)
+        self.assertCount(response, 1)
+        self.assertTrue(response.request.url.endswith('_count?' + urlencode(parameters)))
+
+    @gen_test
     def test_count_specific_query_with_parameters(self):
         source = {"query": {"term": {"_id": "171171"}}}
-        source = self._set_count_query(source)
-        parameters = {'refresh': True}
+        parameters = {'terminate_after': 5}
         response = yield self.es_connection.count(callback=self.stop, source=source, parameters=parameters)
         self.assertCount(response, 1)
-        self.assertTrue(response.request.url.endswith('_count?refresh=True'))
+        self.assertTrue(response.request.url.endswith('_count?' + urlencode(parameters)))
 
     @gen_test
     def test_use_of_custom_http_clients(self):

--- a/tornadoes/tests/unit/test_tornadoes.py
+++ b/tornadoes/tests/unit/test_tornadoes.py
@@ -178,7 +178,7 @@ class TestESConnection(ESConnectionTestBase):
         parameters = {'refresh': True}
         self.es_connection.count(callback=self.stop, source=source, parameters=parameters)
         response = self.wait()
-        if self.version < 5:
+        if self.version[0] < 5:
             self.assertTrue(response.code in [200, 201], "Wrong response code: %d." % response.code)
         else:
             self.assertEqual(response.code, 400)

--- a/tornadoes/tests/unit/test_tornadoes.py
+++ b/tornadoes/tests/unit/test_tornadoes.py
@@ -302,6 +302,7 @@ class TestESConnectionWithTornadoGen(ESConnectionTestBase):
     @gen_test
     def test_count_specific_query_with_parameters(self):
         source = {"query": {"term": {"_id": "171171"}}}
+        source = self._set_count_query(source)
         parameters = {'terminate_after': 5}
         response = yield self.es_connection.count(callback=self.stop, source=source, parameters=parameters)
         self.assertCount(response, 1)


### PR DESCRIPTION
Made some changes to support ES 5.x.
Note that ES 5 validates the URL's parameters of the requests, therefore the search request with custom query (source) did not work, because the create_path method added the source as a URL parameter and the Elasticsearch throw 400 for this illegal argument. Of course I fixed it.